### PR TITLE
Change default handler to support logrotate.

### DIFF
--- a/pretenders/server/settings.py
+++ b/pretenders/server/settings.py
@@ -20,7 +20,7 @@ LOGGING_CONFIG = {
         },
         'file': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.WatchedFileHandler',
             'filename': 'pretenders.log',
             'formatter': 'verbose'
         },


### PR DESCRIPTION
https://docs.python.org/2/library/logging.handlers.html

It can be done via local_settings.py but looks like WatchedFileHandler is a bit more handy for everyone. So it can be used by default.
