### PR TITLE
Fixes to make tests pass on Python3.4

### DIFF
--- a/pretenders/client/__init__.py
+++ b/pretenders/client/__init__.py
@@ -92,7 +92,7 @@ class BossClient(object):
         self.name = name
         self.full_host = "{0}:{1}".format(self.host, self.port)
 
-        self.connection = httplib.HTTPConnection(self.full_host, strict=0)
+        self.connection = httplib.HTTPConnection(self.full_host)
         self.boss_access = APIHelper(self.connection, '')
 
         LOGGER.info('Requesting {0} pretender. Port:{1} Timeout:{2} ({3})'

--- a/pretenders/common/http.py
+++ b/pretenders/common/http.py
@@ -232,5 +232,6 @@ class MatchRule(object):
         :return: True if the request body matches and False if not.
         """
         if self.body:
-            return re.match(self.body, ascii_to_binary(body)) is not None
+            body = ascii_to_binary(body).decode()
+            return re.match(self.body, body) is not None
         return True

--- a/tests/integration/test_http.py
+++ b/tests/integration/test_http.py
@@ -370,6 +370,21 @@ def test_list_history():
     assert_equals(historical_calls[2]['url'], '/call_three')
 
 
+def test_reply_depending_on_body():
+    http_mock.reset()
+    http_mock.when('POST /hello', body=u'1.*').reply(b'First', times=FOREVER)
+    http_mock.when('POST /hello', body=u'2.*').reply(b'Second', times=FOREVER)
+
+    response, data = fake_client.post(url='/hello', body=u'123')
+    assert_equals(data, b'First')
+
+    response, data = fake_client.post(url='/hello', body=u'234')
+    assert_equals(data, b'Second')
+
+    response, data = fake_client.post(url='/hello', body=u'345')
+    assert_equals(response.status, 404)
+
+
 def test_mock_timeout_behaviour():
     timeout_fake_client = get_fake_client(http_mock, timeout=10)
 
@@ -380,17 +395,3 @@ def test_mock_timeout_behaviour():
     assert_raises(socket.timeout,
                   timeout_fake_client.get,
                   url='/test-long-process')
-
-def test_reply_depending_on_body():
-    http_mock.reset()
-    http_mock.when('POST /hello', body=u'1.*').reply('First', times=FOREVER)
-    http_mock.when('POST /hello', body=u'2.*').reply('Second', times=FOREVER)
-
-    response, data = fake_client.post(url='/hello', body='123')
-    assert_equals(data, 'First')
-
-    response, data = fake_client.post(url='/hello', body='234')
-    assert_equals(data, 'Second')
-
-    response, data = fake_client.post(url='/hello', body='345')
-    assert_equals(response.status, 404)


### PR DESCRIPTION
Replaces https://github.com/pretenders/pretenders/pull/114

Thanks @Insoleet for spotting the issue and providing an initial PR.

I have run tests with 2x2 combinations (Python 2 and 3 in both client and server). HTTP mocking works fine now on all cases.

@alexcouper care to review?