### PR TITLE
Dockerize.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.2
+
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
+    apk add --update bash python3 py-pip && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+
+
+RUN mkdir -p /opt/pretenders/
+
+ADD requirements /opt/pretenders/requirements
+
+RUN pip install -r /opt/pretenders/requirements/runtime.txt
+
+ADD pretenders /opt/pretenders/pretenders
+
+EXPOSE 8000
+ENV PYTHONPATH=/opt/pretenders
+
+CMD python -m pretenders.server.server --host 0.0.0.0 --port 8000

--- a/pretenders/server/maintain.py
+++ b/pretenders/server/maintain.py
@@ -6,7 +6,7 @@ import sys
 from pretenders.server import data
 from pretenders.client import BossClient
 
-STALE_DELETE_FREQUENCY = 5
+STALE_DELETE_FREQUENCY = 60
 
 
 def run(host, port):

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,3 @@
-bottle==0.11.6
+bottle==0.12.9
 argparse
+jinja2


### PR DESCRIPTION
This is a preferred way to dockerize (as opposed to https://github.com/pretenders/pretenders-docker) because it includes the html, css and JS files necessary to run the angular app.

![image](https://cloud.githubusercontent.com/assets/837734/12199028/d5a9ffae-b60c-11e5-9722-f1ce333de936.png)
