### PR TITLE
Fix case where one character was stripped off the URL

### DIFF
--- a/pretenders/server/apps/replay.py
+++ b/pretenders/server/apps/replay.py
@@ -46,11 +46,13 @@ def replay_smtp(uid):
     return selected.as_json()
 
 
-@app.route('/mockhttp/<uid><url:path>', method='ANY')
-def replay_http(uid, url):
+@app.route('/mockhttp/<path:path>', method='ANY')
+def replay_http(path):
     """
     Replay a previously recorded preset, and save the request in history
     """
+    uid = path.split('/')[0]
+    url = path[len(uid):]
     pretender.exists_or_404('http', uid)
     request_info = RequestSerialiser(url, bottle.request)
     body = request_info.serialize()

--- a/rtdocs.sh
+++ b/rtdocs.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Run this to force an update of the documentation at Readthedocs
-curl --data '' http://readthedocs.org/build/3502
+curl --data '' http://readthedocs.org/build/pretenders


### PR DESCRIPTION
For mocking SOAP services, sometimes we need the mock base URL to be the base URL for the mocked service. In that case, if the URL doesn't contain an extra path, one character got stripped off the `uid`.