### PR TITLE
Include static and template files in distribution package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.rst
+recursive-include pretenders/server/static *
+recursive-include pretenders/server/templates *


### PR DESCRIPTION
There is an issue with web ui when installing pretenders from PyPI:

```
500 Internal Server Error
Template 'index.html' not found.
```

That's because some files are missing from the distribution package.