### PR TITLE
Fixed binary_to_ascii to function for python2 and python3

### DIFF
--- a/pretenders/common/http.py
+++ b/pretenders/common/http.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import re
+import sys
 from pretenders.common.exceptions import NoRequestFound
 
 
@@ -41,10 +42,16 @@ class RequestSerialiser(object):
         }
         return json.dumps(data)
 
-
 def binary_to_ascii(data):
-    return base64.b64encode(data).decode('ascii')
+    python3 = sys.version_info.major >= 3
 
+    if python3 and isinstance(data, str):
+        input_bytes = data.encode('utf8')
+    else:
+        input_bytes = data
+
+    output_bytes = base64.b64encode(input_bytes)
+    return output_bytes.decode('ascii') if python3 else output_bytes
 
 def ascii_to_binary(data):
     return base64.b64decode(data.encode('ascii'))


### PR DESCRIPTION
This is a fix in reference of #122. I encountered this issue attempting to run your basic hello world example.

base64 behaves differently in python 2 and 3. Python 2 does not have a 'bytes' type and a 'str' type can be used without issue. bytes('test') returns as type 'str'.

In python3 base64 must have a 'bytes' type object. I added a check to convert strings in python 3 before the conversion is done.

with this change the following will work in python 2 and 3.

```
mock = HTTPMock('localhost', 8200, name="test")
mock.when('GET /hello').reply('Hello', times=FOREVER)
mock.when('GET /hello').reply(b'Hello', times=FOREVER)
```

The unit tests all passed locally.