### PR TITLE
case-insensitive headers match instead of case-sensitive

### DIFF
--- a/pretenders/common/http.py
+++ b/pretenders/common/http.py
@@ -213,10 +213,12 @@ class MatchRule(object):
             we're matching against.
         :return: True if the request is a match for headers and False if not.
         """
-        if self.headers:
-            for k, v in self.headers.items():
+        rq_headers = {k.lower(): v for k, v in headers.items()}
+        expected_headers = {k.lower(): v for k, v in self.headers.items()}
+        if expected_headers:
+            for k, v in expected_headers.items():
                 try:
-                    header = headers[k]
+                    header = rq_headers[k]
                 except KeyError:
                     return False
                 else:


### PR DESCRIPTION
Made header matching case-insensitive.

RFC 7230 HTTP/1.1 Message Syntax and Routing June 2014
> 3.2.  Header Fields
>    Each **header field consists of a case-insensitive field name** followed
>    by a colon (":"), optional leading whitespace, the field value, and
>    optional trailing whitespace.

RFC 1945 HTTP/1.0 May 1996
> 4.2  Message Headers
> 
>    HTTP header fields, which include General-Header (Section 4.3),
>    Request-Header (Section 5.2), Response-Header (Section 6.2), and
>    Entity-Header (Section 7.1) fields, follow the same generic format as
>    that given in Section 3.1 of RFC 822 [7]. Each header field consists
>    of a name followed immediately by a colon (":"), a single space (SP)
>    character, and the field value. **Field names are case-insensitive.**
>    Header fields can be extended over multiple lines by preceding each
>    extra line with at least one SP or HT, though this is not
>    recommended.

example:
previously if {"content-type": "application/json"} header is set in MatchRule() and then mock received request with {"Content-Type": "application/json"} header you will not get expected response from this preset.