### PR TITLE
Add form data matching in http requests

### DIFF
--- a/pretenders/client/http.py
+++ b/pretenders/client/http.py
@@ -66,13 +66,16 @@ class HTTPMock(BossClient):
             full_host, self.pretend_access_path
         )
 
-    def when(self, rule='', headers=None, body=None):
+    def when(self, rule='', headers=None, body=None, data=None):
         """
         Set the match rule which is the first part of the Preset.
 
         :param rule: String incorporating the method and url to match
             eg "GET url/to/match"
         :param headers: An optional dictionary of headers to match.
+        :param body: Body to match (string using regex syntax).
+        :param data: Dictionary of form field names and values to match.
+            If present, overrides body parameter (if any).
 
         .. note::
 
@@ -86,7 +89,7 @@ class HTTPMock(BossClient):
             'GET /foo\?bar=1'
 
         """
-        match_rule = MatchRule(rule, headers, body)
+        match_rule = MatchRule(rule, headers, body, data)
         mock = copy(self)
         mock.rule = match_rule
         return mock

--- a/pretenders/common/tests/test_match_rule.py
+++ b/pretenders/common/tests/test_match_rule.py
@@ -1,3 +1,5 @@
+import base64
+
 from nose.tools import assert_true, assert_false
 
 from pretenders.common.http import MatchRule
@@ -10,13 +12,18 @@ DEFAULT_HEADERS = {
 }
 
 
-def create_request(rule, headers=None):
+def create_request(rule, headers=None, body=''):
     request = {'rule': rule}
-    if not headers:
-        headers = {}
+
+    use_headers = {}
+    use_headers.update(DEFAULT_HEADERS)
+
+    if headers:
+        use_headers.update(headers)
+
     # Add other headers to make the tests more realistic
-    headers.update(DEFAULT_HEADERS)
-    request['headers'] = headers
+    request['headers'] = use_headers
+    request['body'] = base64.b64encode(body.encode()).decode()
     return request
 
 
@@ -109,3 +116,78 @@ def test_is_match_with_headers_and_no_request_headers():
     assert_false(match_rule.matches(mock_request))
     assert_true(match_rule.rule_matches(mock_request['rule']))
     assert_false(match_rule.headers_match(mock_request['headers']))
+
+
+def test_is_match_body():
+    """ Test matching against body """
+    match_rule = MatchRule('GET /test-match', body='foo')
+    mock_request_good = create_request('GET /test-match', body='foo')
+    mock_request_bad = create_request('GET /test-match', body='bar')
+
+    assert_true(match_rule.matches(mock_request_good))
+    assert_false(match_rule.matches(mock_request_bad))
+
+
+def test_is_match_data_url_encoded():
+    """ Test match URLencoded form """
+    match_rule = MatchRule('GET /test-match',
+                           data={'one': 'first', 'two': 'second thing'})
+    mock_request_good = create_request('GET /test-match',
+                                       body='one=first&two=second%20thing')
+    mock_request_bad = create_request('GET /test-match',
+                                      body='none=first&two=second')
+
+    assert_true(match_rule.matches(mock_request_good))
+    assert_false(match_rule.matches(mock_request_bad))
+
+
+def test_is_not_match_missing_form_field():
+    """ Test match URLencoded form """
+    match_rule = MatchRule('GET /test-match',
+                           data={'one': 'first', 'two': 'second thing'})
+    mock_request = create_request('GET /test-match',
+                                  body='one=first')
+
+    assert_false(match_rule.matches(mock_request))
+
+def test_is_match_data_multipart():
+    """ Test match multipart form """
+
+    boundary = '----onetwothree'
+    headers = {
+        'Content-Type': 'multipart/form-data; boundary={}'.format(boundary)
+    }
+
+    lines = [
+        boundary,
+        'Content-disposition: form-data; name="one"',
+        '',
+        'first',
+        boundary,
+        'Content-disposition: form-data; name="two"',
+        '',
+        'second'
+    ]
+    body = "\n".join(lines)
+
+    lines = [
+        boundary,
+        'Content-disposition: form-data; name="one"',
+        '',
+        'first',
+        boundary,
+        'Content-disposition: form-data; name="two"',
+        '',
+        'other'
+    ]
+    body_bad = "\n".join(lines)
+
+    match_rule = MatchRule('GET /test-match',
+                           data={'one': 'first', 'two': 'second'})
+    mock_request_good = create_request('GET /test-match',
+                                       body=body, headers=headers)
+    mock_request_bad = create_request('GET /test-match',
+                                      body=body_bad, headers=headers)
+
+    assert_true(match_rule.matches(mock_request_good))
+    assert_false(match_rule.matches(mock_request_bad))

--- a/pretenders/tests/integration/test_http.py
+++ b/pretenders/tests/integration/test_http.py
@@ -385,6 +385,21 @@ def test_reply_depending_on_body():
     assert_equals(response.status, 404)
 
 
+def test_reply_depending_on_data():
+    http_mock.reset()
+    http_mock.when('POST /hello', data={'one': 'first'}).reply(b'First', times=FOREVER)
+    http_mock.when('POST /hello', data={'two': 'second'}).reply(b'Second', times=FOREVER)
+
+    response, data = fake_client.post(url='/hello', body='one=first')
+    assert_equals(data, b'First')
+
+    response, data = fake_client.post(url='/hello', body='two=second')
+    assert_equals(data, b'Second')
+
+    response, data = fake_client.post(url='/hello', body=u'other=values')
+    assert_equals(response.status, 404)
+
+
 def test_mock_timeout_behaviour():
     timeout_fake_client = get_fake_client(http_mock, timeout=10)
 


### PR DESCRIPTION
Wanted to write some tests expecting responses to specific POSTed form data. I didn't like matching on the body text explicitly, since the form fields should mean the same regardless of the order in which they arrived.

This request adds a `data={}` member to `when()` (akin to `headers` and `body`), and tries to intelligently look at the body (URL encoded or multipart), pull out the form values, then check the resulting dictionaries for equivalence. 