### PR TITLE
Use twine for future releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .*/
 tags
 dist/
+build/
 *.egg-info/
 docs/_build
 pep8.txt

--- a/publish.sh
+++ b/publish.sh
@@ -45,7 +45,9 @@ git push origin master
 git push --tags
 
 echo -e "\nUploading to PyPI..."
-python setup.py sdist bdist_wheel upload
+python setup.py sdist bdist_wheel
+twine check dist/*
+twine upload --repository pretenders dist/*
 
 echo -e "\nTriggering a build of the documentation at RTD..."
 sh ./rtdocs.sh

--- a/requirements/maintain.txt
+++ b/requirements/maintain.txt
@@ -1,0 +1,2 @@
+-r dev.txt
+twine


### PR DESCRIPTION
I used twine to release 1.4.5. I have a `~/.pypirc` file that looks like this:

```
[distutils]
 index-servers =
  pretenders
  pretenders-testpypi

[pretenders]
 repository = https://upload.pypi.org/legacy/
 username = __token__
 password = pypi-...
 
[pretenders-testpypi]
 repository = https://test.pypi.org/legacy/
 username = __token__
 password = pypi-...
```

This change only affects how we release to real pypi. I suspect we will automate this very soon...

To release to test pypi I can use locally:

```
twine upload --repository pretenders-testpypi dist/*
```